### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.6.4-stretch
+
+# install base packages
+RUN apt-get clean \
+ && apt-get update --fix-missing \
+ && apt-get install -y \
+    git \
+    curl \
+    gcc \
+    g++ \
+    build-essential \
+    wget \
+    awscli
+
+WORKDIR /work
+
+# install python packages
+COPY dev-requirements.txt dev-requirements.txt
+
+# add the code as the final step so that when we modify the code
+# we don't bust the cached layers holding the dependencies and
+# system packages.
+COPY blackstone/ blackstone/
+COPY setup.py setup.py
+COPY README.md README.md
+COPY scripts/ scripts/
+COPY tests/ tests/
+COPY examples/ examples/
+COPY .flake8 .flake8
+
+RUN pip install -r dev-requirements.txt
+RUN pip install -e .
+RUN pip install https://blackstone-model.s3-eu-west-1.amazonaws.com/en_blackstone_proto-0.0.1.tar.gz
+
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This adds a dockerfile - there will be a follow up PR which adds some continuous integration which uses this.

You can build it like:
```
docker build -t blackstone-test .
```
and then get a shell inside a running container like this:
```
docker run -it blackstone-test
```

Docker is useful because it provides a consistent environment for code, and is generally helpful for other people trying to run blackstone.
