### PR TITLE
Update Spacy Version

### DIFF
--- a/blackstone/version.py
+++ b/blackstone/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "0"
 _MINOR = "1"
-_REVISION = "15"
+_REVISION = "16"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+version = "5.4.3"
 testpaths = tests/

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
         "numpy",
         "pandas"
         ],
-    tests_require=["pytest", "pytest-cov"],
+    tests_require=["pytest==5.4.3", "pytest-cov==2.8.1"],
     python_requires=">=3.6.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     license="Apache",
     install_requires=[
-        "spacy==2.1.8",
+        "spacy==2.1.9",
         "requests", # required for the legislation linker.
         "conllu",
         "numpy",


### PR DESCRIPTION
Fixes memory leak found in Spacy 2.1.8

"This is a small maintenance update that backports a bug fix for a memory leak that'd occur in long-running parsing processes. It's intended for users who can't or don't yet want to upgrade to spaCy v2.2 (e.g. because it requires retraining all the models). If you're able to upgrade, you shouldn't use this version and instead install the latest v2.2." - https://github.com/explosion/spaCy/releases/tag/v2.1.9