### PR TITLE
Update Spacy to 2.1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     license="Apache",
     install_requires=[
-        "spacy==2.1.8",
+        "spacy==2.1.9",
         "requests", # required for the legislation linker.
         "conllu",
         "numpy",


### PR DESCRIPTION
Fix to resolve memory leak in 2.1.8

https://github.com/explosion/spaCy/releases/tag/v2.1.9