### PR TITLE
Fix tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     license="Apache",
     install_requires=[
-        "spacy==2.1.8",
+        "spacy==2.1.9",
         "requests", # required for the legislation linker.
         "conllu",
         "numpy",

--- a/tests/test_legislation_linker.py
+++ b/tests/test_legislation_linker.py
@@ -15,7 +15,7 @@ def mock_set_legislation_target(token):
     run in automated tests.
     """
     if token.text == "Constitutional Reform and Governance Act 2010":
-        return "http://www.legislation.gov.uk/ukpga/2010/25/contents"
+        return "https://www.legislation.gov.uk/ukpga/2010/25/contents"
 
     return "None"
 
@@ -73,7 +73,7 @@ class TestLegislationLinker(unittest.TestCase):
         assert str(relations[0][0]) == "None"
         assert relations[0][1] == "None"
         assert str(relations[0][2]) == "Constitutional Reform and Governance Act 2010"
-        assert relations[0][3] == "http://www.legislation.gov.uk/ukpga/2010/25/contents"
+        assert relations[0][3] == "https://www.legislation.gov.uk/ukpga/2010/25/contents"
 
         # Instrument is the object of a preposition and includes a provision reference
         text = "The Secretary of State went on to describe the negative resolution procedure set out in section 20 of the Constitutional Reform and Governance Act 2010."
@@ -81,10 +81,10 @@ class TestLegislationLinker(unittest.TestCase):
         relations = extract_legislation_relations(doc)
         assert str(relations[0][0]) == "section 20"
         assert (
-            relations[0][1] == "http://www.legislation.gov.uk/ukpga/2010/25/section/20"
+            relations[0][1] == "https://www.legislation.gov.uk/ukpga/2010/25/section/20"
         )
         assert str(relations[0][2]) == "Constitutional Reform and Governance Act 2010"
-        assert relations[0][3] == "http://www.legislation.gov.uk/ukpga/2010/25/contents"
+        assert relations[0][3] == "https://www.legislation.gov.uk/ukpga/2010/25/contents"
 
         # Instrument is a direct object without a provision reference
         text = (
@@ -95,4 +95,4 @@ class TestLegislationLinker(unittest.TestCase):
         assert str(relations[0][0]) == "None"
         assert relations[0][1] == "None"
         assert str(relations[0][2]) == "Constitutional Reform and Governance Act 2010"
-        assert relations[0][3] == "http://www.legislation.gov.uk/ukpga/2010/25/contents"
+        assert relations[0][3] == "https://www.legislation.gov.uk/ukpga/2010/25/contents"

--- a/tests/test_legislation_linker.py
+++ b/tests/test_legislation_linker.py
@@ -44,7 +44,7 @@ class TestLegislationLinker(unittest.TestCase):
         # Act look up
         doc = self.nlp("Constitutional Reform and Governance Act 2010")
         instrument = doc[:]
-        target = "http://www.legislation.gov.uk/ukpga/2010/25/contents"
+        target = "https://www.legislation.gov.uk/ukpga/2010/25/contents"
         assert mock_set_legislation_target(instrument) == target
 
         # 'Act' not present
@@ -55,13 +55,13 @@ class TestLegislationLinker(unittest.TestCase):
     def test_set_provision_target(self):
         # Provision look up
         doc = self.nlp("section 20")
-        url = "http://www.legislation.gov.uk/ukpga/2010/25/contents"
-        target = "http://www.legislation.gov.uk/ukpga/2010/25/section/20"
+        url = "https://www.legislation.gov.uk/ukpga/2010/25/contents"
+        target = "https://www.legislation.gov.uk/ukpga/2010/25/section/20"
         assert set_provision_target(url, doc) == target
 
         # No number matches
         doc = self.nlp("section")
-        url = "http://www.legislation.gov.uk/ukpga/2010/25/contents"
+        url = "https://www.legislation.gov.uk/ukpga/2010/25/contents"
         target = "None"
         assert set_provision_target(url, doc) == target
 


### PR DESCRIPTION
Govt urls now come back as HTTPS, the tests were failing due to references to http://